### PR TITLE
Fixed checking for too long path length

### DIFF
--- a/src/Icon.php
+++ b/src/Icon.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Icons;
+
+use Illuminate\Contracts\Support\Htmlable;
+
+class Icon implements Htmlable
+{
+    /**
+     * @var string|null
+     */
+    protected $content;
+
+    /**
+     * Icon constructor.
+     *
+     * @param string|null $content
+     */
+    public function __construct(string $content = null)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function toHtml(): ?string
+    {
+        return $this->content;
+    }
+}

--- a/src/IconComponent.php
+++ b/src/IconComponent.php
@@ -87,13 +87,15 @@ class IconComponent extends Component
     /**
      * Get the view / contents that represent the component.
      *
-     * @return \Illuminate\View\View|string
+     * @return Icon
      */
     public function render()
     {
         $icon = $this->finder->loadFile($this->path);
 
-        return $this->setAttributes($icon);
+        $content = $this->setAttributes($icon);
+
+        return new Icon($content);
     }
 
     /**

--- a/tests/BladeComponentTest.php
+++ b/tests/BladeComponentTest.php
@@ -42,4 +42,18 @@ class BladeComponentTest extends TestUnitCase
         $this->assertStringContainsString('width="2em"', $view);
         $this->assertStringContainsString('height="2em"', $view);
     }
+
+
+    /**
+     * https://github.com/laravel/framework/issues/32254
+     */
+    public function testLongContentComponent(): void
+    {
+        $this->app->make(IconFinder::class)
+            ->registerIconDirectory('empty', __DIR__ . '/stubs');
+
+        $view = view('icon-long-view-content')->render();
+
+        $this->assertEmpty($view);
+    }
 }

--- a/tests/views/icon-long-view-content.blade.php
+++ b/tests/views/icon-long-view-content.blade.php
@@ -1,0 +1,1 @@
+<x-orchid-icon path="{{ str_repeat('a', 9999999) }}" class="icon-big" width="2em" height="2em" />


### PR DESCRIPTION
Changed calling result from string to `Htmlable` This fixes too long file path length. (https://github.com/laravel/framework/issues/32254)