### PR TITLE
fix usage IconComponent render function

### DIFF
--- a/src/IconComponent.php
+++ b/src/IconComponent.php
@@ -89,10 +89,10 @@ class IconComponent extends Component
      */
     public function render(): callable
     {
-        return function (array $data) {
+        return function (array $data = []) {
             return view('blade-icon::icon', [
                 'html' => $this->finder->loadFile($this->path),
-                'data' => collect($this->extractPublicProperties())->merge($data['attributes'])->filter(fn($value) => is_string($value)),
+                'data' => collect($this->extractPublicProperties())->merge($data['attributes'] ?? [])->filter(fn($value) => is_string($value)),
             ]);
         };
     }


### PR DESCRIPTION
After the update there was a problem with the display of icons as follows:

```
resolve(
    IconComponent::class,
    ['path' => 'star']
)->render()();
```


Now the function that 'render' returns requires an array with the 'attributes' key and it must be passed everywhere

```
resolve(
    IconComponent::class,
    ['path' => 'star']
)->render()(['attributes' => []]);
```